### PR TITLE
Ensure addresses are checksum addresses

### DIFF
--- a/packages/node/src/ethereum/api.ethereum.ts
+++ b/packages/node/src/ethereum/api.ethereum.ts
@@ -166,7 +166,7 @@ export class EthereumApi implements ApiWrapper<EthereumBlockWrapper> {
         return new EthereumBlockWrapped(block, txs);
       } catch (e) {
         // Method not avaialble https://eips.ethereum.org/EIPS/eip-1474
-        if (e.error.code === -32601) {
+        if (e?.error?.code === -32601) {
           logger.warn(
             `The endpoint doesn't support 'eth_getBlockReceipts', individual receipts will be fetched instead, this will greatly impact performance.`,
           );

--- a/packages/node/src/ethereum/api.service.ethereum.test.ts
+++ b/packages/node/src/ethereum/api.service.ethereum.test.ts
@@ -1,0 +1,71 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { INestApplication } from '@nestjs/common';
+import { EventEmitterModule } from '@nestjs/event-emitter';
+import { Test } from '@nestjs/testing';
+import { delay } from '@subql/node-core';
+import { GraphQLSchema } from 'graphql';
+import { range } from 'lodash';
+import { SubqueryProject } from '../configure/SubqueryProject';
+import { EthereumApiService } from './api.service.ethereum';
+
+// Add api key to work
+const WS_ENDPOINT = 'wss://eth.api.onfinality.io/ws?apikey=';
+const HTTP_ENDPOINT = 'https://eth.api.onfinality.io/rpc?apikey=';
+
+function testSubqueryProject(endpoint: string): SubqueryProject {
+  return {
+    network: {
+      endpoint,
+      chainId: '1',
+    },
+    dataSources: [],
+    id: 'test',
+    root: './',
+    schema: new GraphQLSchema({}),
+    templates: [],
+  };
+}
+
+jest.setTimeout(90000);
+describe('ApiService', () => {
+  let app: INestApplication;
+
+  afterEach(async () => {
+    return app?.close();
+  });
+
+  const prepareApiService = async (
+    endpoint: string = HTTP_ENDPOINT,
+  ): Promise<EthereumApiService> => {
+    const module = await Test.createTestingModule({
+      providers: [
+        {
+          provide: 'ISubqueryProject',
+          useFactory: () => testSubqueryProject(endpoint),
+        },
+        EthereumApiService,
+      ],
+      imports: [EventEmitterModule.forRoot()],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+    const apiService = app.get(EthereumApiService);
+    await apiService.init();
+    return apiService;
+  };
+
+  it('can instantiate api', async () => {
+    const apiService = await prepareApiService();
+    console.log(apiService.api.getChainId());
+    await delay(0.5);
+  });
+
+  it('can fetch blocks', async () => {
+    const apiService = await prepareApiService();
+    await apiService.api.fetchBlocks(range(12369621, 12369651));
+    await delay(0.5);
+  });
+});

--- a/packages/node/src/ethereum/utils.ethereum.ts
+++ b/packages/node/src/ethereum/utils.ethereum.ts
@@ -36,81 +36,52 @@ function handleNumber(value: string | number): BigNumber {
 }
 
 export function formatBlock(block: Record<string, any>): EthereumBlock {
-  const newBlock: EthereumBlock = {
+  return {
+    ...block,
     difficulty: handleNumber(block.difficulty).toBigInt(),
-    extDataGasUsed: block.extDataGasUsed,
-    extDataHash: block.extDataHash,
     gasLimit: handleNumber(block.gasLimit).toBigInt(),
     gasUsed: handleNumber(block.gasUsed).toBigInt(),
-    hash: block.hash,
-    logsBloom: block.logsBloom,
-    miner: block.miner,
-    mixHash: block.mixHash,
-    nonce: block.nonce,
     number: handleNumber(block.number).toNumber(),
-    parentHash: block.parentHash,
-    receiptsRoot: block.receiptsRoot,
-    sha3Uncles: block.sha3Uncles,
     size: handleNumber(block.size).toBigInt(),
-    stateRoot: block.stateRoot,
     timestamp: handleNumber(block.timestamp).toBigInt(),
     totalDifficulty: handleNumber(block.totalDifficulty).toBigInt(),
-    transactions: block.transactions,
-    transactionsRoot: block.transactionsRoot,
-    uncles: block.uncles,
     baseFeePerGas: block.baseFeePerGas
       ? handleNumber(block.baseFeePerGas).toBigInt()
       : undefined,
     blockGasCost: block.blockGasCost
       ? handleNumber(block.blockGasCost).toBigInt()
       : undefined,
-    blockExtraData: block.blockExtraData,
     logs: [], // Filled in at AvalancheBlockWrapped constructor
-  };
-
-  return newBlock;
+  } as EthereumBlock;
 }
 export function formatLog(
   log: EthereumLog<EthereumResult> | EthereumLog,
   block: EthereumBlock,
 ): EthereumLog<EthereumResult> | EthereumLog {
-  const newLog: EthereumLog<EthereumResult> = {
-    address: log.address,
-    topics: log.topics,
-    data: log.data,
+  return {
+    ...log,
+    address: handleAddress(log.address),
     blockNumber: handleNumber(log.blockNumber).toNumber(),
-    transactionHash: log.transactionHash,
     transactionIndex: handleNumber(log.transactionIndex).toNumber(),
-    blockHash: log.blockHash,
     logIndex: handleNumber(log.logIndex).toNumber(),
-    removed: log.removed,
-    args: log.args,
     block,
-  };
-  return newLog;
+  } as EthereumLog<EthereumResult>;
 }
 
 export function formatTransaction(
   tx: Record<string, any>,
 ): EthereumTransaction {
-  const transaction: EthereumTransaction = {
-    blockHash: tx.blockHash,
+  return {
+    ...tx,
+    from: handleAddress(tx.from),
+    to: handleAddress(tx.to),
     blockNumber: handleNumber(tx.blockNumber).toNumber(),
-    from: tx.from,
     gas: handleNumber(tx.gas).toBigInt(),
     gasPrice: handleNumber(tx.gasPrice).toBigInt(),
-    hash: tx.hash,
-    input: tx.input,
     nonce: handleNumber(tx.nonce).toBigInt(),
-    to: tx.to,
     transactionIndex: handleNumber(tx.transactionIndex).toBigInt(),
     value: handleNumber(tx.value).toBigInt(),
-    type: tx.type,
     v: handleNumber(tx.v).toBigInt(),
-    r: tx.r,
-    s: tx.s,
-    accessList: tx.accessList,
-    chainId: tx.chainId,
     maxFeePerGas: tx.maxFeePerGas
       ? handleNumber(tx.maxFeePerGas).toBigInt()
       : undefined,
@@ -118,29 +89,23 @@ export function formatTransaction(
       ? handleNumber(tx.maxPriorityFeePerGas).toBigInt()
       : undefined,
     receipt: undefined, // Filled in at AvalancheApi.fetchBlocks
-  };
-  return transaction;
+  } as EthereumTransaction;
 }
 
 export function formatReceipt(
   receipt: Record<string, any>,
   block: EthereumBlock,
 ): EthereumReceipt {
-  const newReceipt: EthereumReceipt = {
-    blockHash: receipt.blockHash,
+  return {
+    ...receipt,
+    from: handleAddress(receipt.from),
+    to: handleAddress(receipt.to),
     blockNumber: handleNumber(receipt.blockNumber).toNumber(),
-    contractAddress: receipt.contractAddress,
     cumulativeGasUsed: handleNumber(receipt.cumulativeGasUsed).toBigInt(),
     effectiveGasPrice: handleNumber(receipt.effectiveGasPrice).toBigInt(),
-    from: receipt.from,
     gasUsed: handleNumber(receipt.gasUsed).toBigInt(),
     logs: receipt.logs.map((log) => formatLog(log, block)),
-    logsBloom: receipt.logsBloom,
     status: Boolean(handleNumber(receipt.status).toNumber()),
-    to: receipt.to,
-    transactionHash: receipt.transactionHash,
     transactionIndex: handleNumber(receipt.transactionIndex).toNumber(),
-    type: receipt.type,
-  };
-  return newReceipt;
+  } as EthereumReceipt;
 }

--- a/packages/node/src/ethereum/utils.ethereum.ts
+++ b/packages/node/src/ethereum/utils.ethereum.ts
@@ -18,8 +18,8 @@ export function calcInterval(api: ApiWrapper): number {
   return 6000;
 }
 
-function handleAddress(value: string): string {
-  if (value === '0x') {
+function handleAddress(value: string): string | null {
+  if (!value || value === '0x') {
     return null;
   }
   return getAddress(value);

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -219,12 +219,12 @@ export class IndexerManager {
   ): Promise<void> {
     await this.indexBlockContent(block, dataSources, getVM);
 
-    for (const log of logs) {
-      await this.indexEvent(log, dataSources, getVM);
-    }
-
     for (const tx of transactions) {
       await this.indexExtrinsic(tx, dataSources, getVM);
+
+      for (const log of logs.filter((l) => l.transactionHash === tx.hash)) {
+        await this.indexEvent(log, dataSources, getVM);
+      }
     }
   }
 


### PR DESCRIPTION
# Description
In https://github.com/subquery/subql-ethereum/pull/23 we switched using an api that provided extra parsing by Ethers, this lead to addresses not being converted to checksum addresses. This also fixes other address scenarios where this could happen.

This also fixes the order which events and transactions are handled. Rather than processing transactions followed by logs it will now process a transaction then its logs before repeating with the remaining transactions and their logs

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
