### PR TITLE
Check queue for lower blocks before processing fetched blocks

### DIFF
--- a/packages/node/src/indexer/blockDispatcher/block-dispatcher.service.ts
+++ b/packages/node/src/indexer/blockDispatcher/block-dispatcher.service.ts
@@ -142,10 +142,16 @@ export class BlockDispatcherService
 
         const blocks = await this.fetchBlocksBatches(blockNums);
 
-        if (bufferedHeight > this._latestBufferedHeight) {
-          logger.debug(`Queue was reset for new DS, discarding fetched blocks`);
+        // Check if the queues have been flushed between queue.takeMany and fetchBlocksBatches resolving
+        // Peeking the queue is because the latestBufferedHeight could have regrown since fetching block
+        if (
+          bufferedHeight > this._latestBufferedHeight ||
+          this.queue.peek() < Math.min(...blockNums)
+        ) {
+          logger.warn(`Queue was reset for new DS, discarding fetched blocks`);
           continue;
         }
+
         const blockTasks = blocks.map((block) => async () => {
           const height = block.blockHeight;
           try {

--- a/packages/node/src/indexer/blockDispatcher/block-dispatcher.service.ts
+++ b/packages/node/src/indexer/blockDispatcher/block-dispatcher.service.ts
@@ -148,7 +148,7 @@ export class BlockDispatcherService
           bufferedHeight > this._latestBufferedHeight ||
           this.queue.peek() < Math.min(...blockNums)
         ) {
-          logger.warn(`Queue was reset for new DS, discarding fetched blocks`);
+          logger.info(`Queue was reset for new DS, discarding fetched blocks`);
           continue;
         }
 

--- a/packages/node/src/indexer/dictionary.service.ts
+++ b/packages/node/src/indexer/dictionary.service.ts
@@ -37,7 +37,7 @@ export class DictionaryService
       );
       return resp.data.chainAlias.value;
     } catch (e) {
-      logger.warn(e, `failed to fetch evm chainId from dictionary`);
+      logger.debug(e, `failed to fetch evm chainId from dictionary`);
       return undefined;
     }
   }


### PR DESCRIPTION
# Description
Fixes error with out of order blocks when there are many dynamic datasources created

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
