### PR TITLE
Add query limit for num of filter address

### DIFF
--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -44,6 +44,7 @@ const DICTIONARY_MAX_QUERY_SIZE = 10000;
 const CHECK_MEMORY_INTERVAL = 60000;
 const MINIMUM_BATCH_SIZE = 5;
 const INTERVAL_PERCENT = 0.9;
+const QUERY_ADDRESS_LIMIT = 50;
 
 function eventFilterToQueryEntry(
   filter: EthereumLogFilter,
@@ -54,7 +55,7 @@ function eventFilterToQueryEntry(
   if (Array.isArray(dsOptions)) {
     const addresses = dsOptions.map((option) => option.address).filter(Boolean);
 
-    if (addresses.length) {
+    if (addresses.length <= QUERY_ADDRESS_LIMIT) {
       conditions.push({
         field: 'address',
         value: addresses,


### PR DESCRIPTION
# Description

Due to too much addresses in filter query could response 413, this add a query limit for filter number of addresses. Default set to 50. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
