### PR TITLE
Fix latestBufferedHeight not progressing with empty dictionary result

### DIFF
--- a/packages/node/src/indexer/blockDispatcher/worker-block-dispatcher.service.ts
+++ b/packages/node/src/indexer/blockDispatcher/worker-block-dispatcher.service.ts
@@ -122,7 +122,10 @@ export class WorkerBlockDispatcherService
   }
 
   enqueueBlocks(heights: number[], latestBufferHeight?: number): void {
-    if (!heights.length) return;
+    if (!!latestBufferHeight && !heights.length) {
+      this.latestBufferedHeight = latestBufferHeight;
+      return;
+    }
     logger.info(
       `Enqueing blocks [${heights[0]}...${last(heights)}], total ${
         heights.length


### PR DESCRIPTION
# Description
Brings over code from main sdk that would progress the last buffered height if the dictionary result was empty.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
