### PR TITLE
check result from json-rpc-batch request is array

### DIFF
--- a/packages/node/src/ethereum/ethers/json-rpc-batch-provider.ts
+++ b/packages/node/src/ethereum/ethers/json-rpc-batch-provider.ts
@@ -106,6 +106,15 @@ export class JsonRpcBatchProvider extends JsonRpcProvider {
         // }
 
         // https://github.com/ethers-io/ethers.js/pull/2657
+        if (!Array.isArray(result)) {
+          const error = new Error(
+            'Invalid response \n' + JSON.stringify(result),
+          );
+          batch.forEach((inflightRequest) => {
+            inflightRequest.reject(error);
+          });
+          return;
+        }
         const resultMap = result.reduce((resultMap, payload) => {
           resultMap[payload.id] = payload;
           return resultMap;


### PR DESCRIPTION
# Description
If an RPC provider returns an error on a batch request, then the response is not an array but a single error response. We need to add a check to see if the response is an array or not

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
