### PR TITLE
New method of resolving chain alises

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -36,6 +36,7 @@
     "cron-converter": "^1.0.2",
     "ethers": "^5.7.0",
     "eventemitter2": "^6.4.5",
+    "json5": "^2.2.3",
     "lodash": "^4.17.21",
     "pg": "^8.7.1",
     "reflect-metadata": "^0.1.13",

--- a/packages/node/src/ethereum/api.service.ethereum.ts
+++ b/packages/node/src/ethereum/api.service.ethereum.ts
@@ -78,7 +78,7 @@ export class EthereumApiService extends ApiService {
           // });
           if (!this.networkMeta) {
             this.networkMeta = {
-              chain: api.getRuntimeChain(),
+              chain: api.getChainId().toString(),
               specName: api.getSpecName(),
               genesisHash: api.getGenesisHash(),
             };
@@ -87,8 +87,8 @@ export class EthereumApiService extends ApiService {
           if (network.chainId !== api.getChainId().toString()) {
             throw this.metadataMismatchError(
               'ChainId',
-              this.networkMeta.genesisHash,
-              api.getRuntimeChain(),
+              network.chainId,
+              api.getChainId().toString(),
             );
           }
 

--- a/packages/node/src/indexer/dictionary.service.ts
+++ b/packages/node/src/indexer/dictionary.service.ts
@@ -10,6 +10,9 @@ import JSON5 from 'json5';
 import fetch from 'node-fetch';
 import { SubqueryProject } from '../configure/SubqueryProject';
 
+const CHAIN_ALIASES_URL =
+  'https://raw.githubusercontent.com/subquery/templates/main/chainAliases.json5';
+
 @Injectable()
 export class DictionaryService
   extends CoreDictionaryService
@@ -39,9 +42,7 @@ export class DictionaryService
   }
 
   private async getEvmChainId(): Promise<Record<string, string>> {
-    const response = await fetch(
-      'https://raw.githubusercontent.com/subquery/templates/main/chainAliases.json5',
-    );
+    const response = await fetch(CHAIN_ALIASES_URL);
 
     const raw = await response.text();
     // We use JSON5 here because the file has comments in it

--- a/packages/node/src/indexer/dictionary.service.ts
+++ b/packages/node/src/indexer/dictionary.service.ts
@@ -1,17 +1,14 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client/core';
 import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
 import {
   NodeConfig,
   DictionaryService as CoreDictionaryService,
-  timeout,
-  getLogger,
 } from '@subql/node-core';
+import JSON5 from 'json5';
+import fetch from 'node-fetch';
 import { SubqueryProject } from '../configure/SubqueryProject';
-
-const logger = getLogger('dictionary');
 
 @Injectable()
 export class DictionaryService
@@ -25,20 +22,13 @@ export class DictionaryService
     super(project.network.dictionary, project.network.chainId, nodeConfig);
   }
 
-  async getEvmChainId(): Promise<string> {
-    const query = `query{chainAlias(id: "evmChainId"){value}}`;
+  async getEvmChainId(): Promise<Record<string, string>> {
+    const response = await fetch(
+      'https://raw.githubusercontent.com/subquery/templates/main/chainAliases.json5',
+    );
 
-    try {
-      const resp = await timeout(
-        this.client.query({
-          query: gql(query),
-        }),
-        this.nodeConfig.dictionaryTimeout,
-      );
-      return resp.data.chainAlias.value;
-    } catch (e) {
-      logger.debug(`Dictionary doesn't have an evmChainId set`);
-      return undefined;
-    }
+    const raw = await response.text();
+    // We use JSON5 here because the file has comments in it
+    return JSON5.parse(raw);
   }
 }

--- a/packages/node/src/indexer/dictionary.service.ts
+++ b/packages/node/src/indexer/dictionary.service.ts
@@ -22,7 +22,23 @@ export class DictionaryService
     super(project.network.dictionary, project.network.chainId, nodeConfig);
   }
 
-  async getEvmChainId(): Promise<Record<string, string>> {
+  async init(): Promise<void> {
+    /*Some dictionarys for EVM are built with other SDKs as they are chains with an EVM runtime
+     * we maintain a list of aliases so we can map the evmChainId to the genesis hash of the other SDKs
+     * e.g moonbeam is built with Substrate SDK but can be used as an EVM dictionary
+     */
+    const chainAliases = await this.getEvmChainId();
+    const chainAlias = chainAliases[this.chainId];
+
+    if (chainAlias) {
+      // Cast as any to work around read only
+      (this.chainId as any) = chainAlias;
+    }
+
+    await super.init();
+  }
+
+  private async getEvmChainId(): Promise<Record<string, string>> {
     const response = await fetch(
       'https://raw.githubusercontent.com/subquery/templates/main/chainAliases.json5',
     );

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -278,7 +278,10 @@ export class FetchService extends BaseFetchService<
     metaData: MetaData,
   ): Promise<boolean> {
     return Promise.resolve(
-      metaData.genesisHash !== this.dictionaryService.chainId,
+      // When alias is not used
+      metaData.genesisHash !== this.api.getGenesisHash() &&
+        // Case when an alias is used
+        metaData.genesisHash !== this.dictionaryService.chainId,
     );
   }
 

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -277,12 +277,8 @@ export class FetchService extends BaseFetchService<
   protected async validatateDictionaryMeta(
     metaData: MetaData,
   ): Promise<boolean> {
-    return (
-      metaData.genesisHash !== this.api.getGenesisHash() &&
-      metaData.genesisHash !==
-        (await this.dictionaryService.getEvmChainId())[
-          this.api.getChainId().toString()
-        ]
+    return Promise.resolve(
+      metaData.genesisHash !== this.dictionaryService.chainId,
     );
   }
 

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -277,11 +277,12 @@ export class FetchService extends BaseFetchService<
   protected async validatateDictionaryMeta(
     metaData: MetaData,
   ): Promise<boolean> {
-    const evmChainId = await this.dictionaryService.getEvmChainId();
-
     return (
       metaData.genesisHash !== this.api.getGenesisHash() &&
-      evmChainId !== this.api.getChainId().toString()
+      metaData.genesisHash !==
+        (await this.dictionaryService.getEvmChainId())[
+          this.api.getChainId().toString()
+        ]
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2784,6 +2784,7 @@ __metadata:
     dotenv: ^15.0.1
     ethers: ^5.7.0
     eventemitter2: ^6.4.5
+    json5: ^2.2.3
     lodash: ^4.17.21
     nodemon: ^2.0.15
     pg: ^8.7.1
@@ -8230,6 +8231,15 @@ __metadata:
   bin:
     json5: lib/cli.js
   checksum: e76ea23dbb8fc1348c143da628134a98adf4c5a4e8ea2adaa74a80c455fc2cdf0e2e13e6398ef819bfe92306b610ebb2002668ed9fc1af386d593691ef346fc3
+  languageName: node
+  linkType: hard
+
+"json5@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "json5@npm:2.2.3"
+  bin:
+    json5: lib/cli.js
+  checksum: 2a7436a93393830bce797d4626275152e37e877b265e94ca69c99e3d20c2b9dab021279146a39cdb700e71b2dd32a4cebd1514cd57cee102b1af906ce5040349
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
This is a new way of resolving chain aliases that means that we no longer need to modify dictionaries. This also works with resolving network dictionaries where previously it didn't.

It also fixes the `runtimeChain` being incorrectly used as the `chainId`. This would result in a lot of chain ids being "unknown"

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
