### PR TITLE
Implement Retry logic for SafeEthProvider

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,3 +61,4 @@ jobs:
                   skip-step: install
                   working-directory: ${{ matrix.path }}
                   test-script: yarn test-jest
+                  annotations: none

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -109,7 +109,7 @@ export class IndexerManager extends BaseIndexerManager<
 
   // eslint-disable-next-line @typescript-eslint/require-await
   private async getApi(block: EthereumBlockWrapper): Promise<SafeEthProvider> {
-    return this.apiService.api.getSafeApi(this.getBlockHeight(block));
+    return this.apiService.safeApi(this.getBlockHeight(block));
   }
 
   protected async indexBlockData(


### PR DESCRIPTION
# Description
Currently when one endpoint that is picked to perform a contract query in the mapping failed, the node will crash. Implementing retry logic for safe api will use a different endpoint from connection pool instead of crashing.

Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
