### PR TITLE
cache result from eth_chainId

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+## Fixed
+- Limit the number of calls to eth_chainId (#123)
 
 ## [2.8.0] - 2023-06-27
 ### Changed


### PR DESCRIPTION
# Description
Cache chainId in `JsonBatchRpcProvider` to prevent multiple calls to `eth_chainId`

Fixes https://github.com/subquery/subql/issues/1856

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
