### PR TITLE
Fix finalization check on BSC

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,10 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Finalization check with BSC and improved rate limit handling (#126)
 
 ## [2.9.0] - 2023-07-05
 ### Fixed
 - Limit the number of calls to eth_chainId (#123)
+
 ### Added
 - `store-cache-upper-limit` flag to limit the max size of the store cache. (#124)
 

--- a/packages/node/src/ethereum/api.ethereum.test.ts
+++ b/packages/node/src/ethereum/api.ethereum.test.ts
@@ -38,7 +38,7 @@ describe('Api.ethereum', () => {
   let ethApi: EthereumApi;
   const eventEmitter = new EventEmitter2();
   let blockData: EthereumBlockWrapped;
-  beforeAll(async () => {
+  beforeEach(async () => {
     ethApi = new EthereumApi(HTTP_ENDPOINT, eventEmitter);
     await ethApi.init();
     blockData = await ethApi.fetchBlock(16258633, true);
@@ -165,5 +165,35 @@ describe('Api.ethereum', () => {
       }
     });
     expect(result.length).toBe(2);
+  });
+
+  it('Resolves the correct tags for finalization', async () => {
+    // Ethereum
+    expect((ethApi as any).supportsFinalized).toBeTruthy();
+    expect((ethApi as any).supportsSafe).toBeTruthy();
+
+    // Moonbeam
+    ethApi = new EthereumApi('https://rpc.api.moonbeam.network', eventEmitter);
+    await ethApi.init();
+
+    expect((ethApi as any).supportsFinalized).toBeTruthy();
+    expect((ethApi as any).supportsSafe).toBeTruthy();
+
+    // BSC
+    ethApi = new EthereumApi('https://bsc-dataseed1.binance.org', eventEmitter);
+    await ethApi.init();
+
+    expect((ethApi as any).supportsFinalized).toBeTruthy();
+    expect((ethApi as any).supportsSafe).toBeFalsy();
+
+    // Polygon
+    ethApi = new EthereumApi(
+      'https://polygon.api.onfinality.io/public',
+      eventEmitter,
+    );
+    await ethApi.init();
+
+    expect((ethApi as any).supportsFinalized).toBeFalsy();
+    expect((ethApi as any).supportsSafe).toBeFalsy();
   });
 });

--- a/packages/node/src/ethereum/api.ethereum.test.ts
+++ b/packages/node/src/ethereum/api.ethereum.test.ts
@@ -169,22 +169,19 @@ describe('Api.ethereum', () => {
 
   it('Resolves the correct tags for finalization', async () => {
     // Ethereum
-    expect((ethApi as any).supportsFinalized).toBeTruthy();
-    expect((ethApi as any).supportsSafe).toBeTruthy();
+    expect((ethApi as any).supportsFinalization).toBeTruthy();
 
     // Moonbeam
     ethApi = new EthereumApi('https://rpc.api.moonbeam.network', eventEmitter);
     await ethApi.init();
 
-    expect((ethApi as any).supportsFinalized).toBeTruthy();
-    expect((ethApi as any).supportsSafe).toBeTruthy();
+    expect((ethApi as any).supportsFinalization).toBeTruthy();
 
     // BSC
-    ethApi = new EthereumApi('https://bsc-dataseed1.binance.org', eventEmitter);
+    ethApi = new EthereumApi('https://bsc-dataseed.binance.org', eventEmitter);
     await ethApi.init();
 
-    expect((ethApi as any).supportsFinalized).toBeTruthy();
-    expect((ethApi as any).supportsSafe).toBeFalsy();
+    expect((ethApi as any).supportsFinalized).toBeFalsy();
 
     // Polygon
     ethApi = new EthereumApi(
@@ -194,6 +191,5 @@ describe('Api.ethereum', () => {
     await ethApi.init();
 
     expect((ethApi as any).supportsFinalized).toBeFalsy();
-    expect((ethApi as any).supportsSafe).toBeFalsy();
   });
 });


### PR DESCRIPTION
# Description
BSC supports the `finalized` block tag but not the `safe` block tag. The check previously assumed that if `finalized` is available then `safe` was too. Now we check for each individually.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
