### PR TITLE
Fallback from batch provider to singular provider

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fallback to singular provider if batch provider is not supported (#144)
 
 ## [2.11.1] - 2023-08-14
 ### Changed

--- a/packages/node/src/ethereum/api.ethereum.ts
+++ b/packages/node/src/ethereum/api.ethereum.ts
@@ -129,17 +129,35 @@ export class EthereumApi implements ApiWrapper<EthereumBlockWrapper> {
 
   async init(): Promise<void> {
     this.injectClient();
-    const [genesisBlock, network, supportsFinalization, supportsSafe] =
-      await Promise.all([
-        this.client.getBlock('earliest'),
-        this.client.getNetwork(),
-        this.getSupportsTag('finalized'),
-        this.getSupportsTag('safe'),
-      ]);
-    this.genesisBlock = genesisBlock;
-    this.supportsFinalization = supportsFinalization && supportsSafe;
-    this.chainId = network.chainId;
-    this.name = network.name;
+
+    try {
+      const [genesisBlock, network, supportsFinalization, supportsSafe] =
+        await Promise.all([
+          this.client.getBlock('earliest'),
+          this.client.getNetwork(),
+          this.getSupportsTag('finalized'),
+          this.getSupportsTag('safe'),
+        ]);
+
+      this.genesisBlock = genesisBlock;
+      this.supportsFinalization = supportsFinalization && supportsSafe;
+      this.chainId = network.chainId;
+      this.name = network.name;
+    } catch (e) {
+      //batch request error for filecoin
+      if (e.message.includes('"message":"we can\'t execute this request"')) {
+        this.client = this.nonBatchClient;
+
+        logger.warn(
+          `The RPC Node at ${this.endpoint} cannot process batch requests. ` +
+            `Switching to non-batch mode for subsequent requests. Please consider checking if batch processing is supported on the RPC node.`,
+        );
+
+        return this.init();
+      }
+
+      throw e;
+    }
   }
 
   private async getSupportsTag(tag: BlockTag): Promise<boolean> {

--- a/packages/node/src/ethereum/api.ethereum.ts
+++ b/packages/node/src/ethereum/api.ethereum.ts
@@ -144,8 +144,7 @@ export class EthereumApi implements ApiWrapper<EthereumBlockWrapper> {
       this.chainId = network.chainId;
       this.name = network.name;
     } catch (e) {
-      //batch request error for filecoin
-      if (e.message.includes('"message":"we can\'t execute this request"')) {
+      if ((e as Error).message.startsWith('Invalid response')) {
         this.client = this.nonBatchClient;
 
         logger.warn(


### PR DESCRIPTION
# Description
With the ETH sdk we use the batch http provider by default. Some RPC endpoints don't support batch requests. We should instead fallback to using the singular provider if this happens

Fixes https://github.com/subquery/subql/issues/1941

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
