### PR TITLE
add custom provider for celo

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fallback to singular provider if batch provider is not supported (#144)
-
-### Fixed
 - Fix missing ds option for event in dictionary query entries (#145)
+
+### Added
+- Custom provider for Celo (#147)
 
 ## [2.11.1] - 2023-08-14
 ### Changed

--- a/packages/node/src/ethereum/ethers/celo/celo-json-rpc-batch-provider.spec.ts
+++ b/packages/node/src/ethereum/ethers/celo/celo-json-rpc-batch-provider.spec.ts
@@ -1,0 +1,36 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import { BigNumber, constants, utils } from 'ethers';
+import { formatBlock } from '../../utils.ethereum';
+import { CeloJsonRpcBatchProvider } from './celo-json-rpc-batch-provider';
+
+describe('CeloJsonRpcProvider', () => {
+  let provider: CeloJsonRpcBatchProvider;
+
+  beforeEach(() => {
+    provider = new CeloJsonRpcBatchProvider('https://forno.celo.org');
+  });
+
+  // Test if gasLimit is correctly set for blocks before the hard fork
+  it('should set gasLimit to zero for blocks before the hard fork', async () => {
+    const block = formatBlock(
+      await provider.send('eth_getBlockByNumber', [
+        utils.hexValue(16068684),
+        true,
+      ]),
+    );
+    expect(BigNumber.from(block.gasLimit)).toEqual(constants.Zero);
+  });
+
+  // Test if gasLimit is correctly set for blocks after the hard fork
+  it('should not set gasLimit to zero for blocks after the hard fork', async () => {
+    const block = formatBlock(
+      await provider.send('eth_getBlockByNumber', [
+        utils.hexValue(21055596),
+        true,
+      ]),
+    );
+    expect(BigNumber.from(block.gasLimit)).toEqual(BigNumber.from(0x1312d00));
+  });
+});

--- a/packages/node/src/ethereum/ethers/celo/celo-json-rpc-batch-provider.ts
+++ b/packages/node/src/ethereum/ethers/celo/celo-json-rpc-batch-provider.ts
@@ -1,0 +1,31 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import { Networkish } from '@ethersproject/networks';
+import { getLogger } from '@subql/node-core';
+import { BigNumber, constants } from 'ethers';
+import { JsonRpcBatchProvider } from '../json-rpc-batch-provider';
+import { ConnectionInfo } from '../web';
+
+const logger = getLogger('celo-batch-provider');
+
+export class CeloJsonRpcBatchProvider extends JsonRpcBatchProvider {
+  private flanHardForkBlock = BigNumber.from('16068685');
+  constructor(url?: ConnectionInfo | string, network?: Networkish) {
+    super(url, network);
+
+    const originalBlockFormatter = this.formatter._block;
+    this.formatter._block = (value, format) => {
+      return originalBlockFormatter(
+        {
+          gasLimit:
+            BigNumber.from(value.number) < this.flanHardForkBlock
+              ? constants.Zero
+              : value.gasLimit,
+          ...value,
+        },
+        format,
+      );
+    };
+  }
+}

--- a/packages/node/src/ethereum/ethers/celo/celo-json-rpc-provider.spec.ts
+++ b/packages/node/src/ethereum/ethers/celo/celo-json-rpc-provider.spec.ts
@@ -1,0 +1,36 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import { BigNumber, constants, utils } from 'ethers';
+import { formatBlock } from '../../utils.ethereum';
+import { CeloJsonRpcProvider } from './celo-json-rpc-provider';
+
+describe('CeloJsonRpcProvider', () => {
+  let provider: CeloJsonRpcProvider;
+
+  beforeEach(() => {
+    provider = new CeloJsonRpcProvider('https://forno.celo.org');
+  });
+
+  // Test if gasLimit is correctly set for blocks before the hard fork
+  it('should set gasLimit to zero for blocks before the hard fork', async () => {
+    const block = formatBlock(
+      await provider.send('eth_getBlockByNumber', [
+        utils.hexValue(16068684),
+        true,
+      ]),
+    );
+    expect(BigNumber.from(block.gasLimit)).toEqual(constants.Zero);
+  });
+
+  // Test if gasLimit is correctly set for blocks after the hard fork
+  it('should not set gasLimit to zero for blocks after the hard fork', async () => {
+    const block = formatBlock(
+      await provider.send('eth_getBlockByNumber', [
+        utils.hexValue(21055596),
+        true,
+      ]),
+    );
+    expect(BigNumber.from(block.gasLimit)).toEqual(BigNumber.from(0x1312d00));
+  });
+});

--- a/packages/node/src/ethereum/ethers/celo/celo-json-rpc-provider.ts
+++ b/packages/node/src/ethereum/ethers/celo/celo-json-rpc-provider.ts
@@ -1,0 +1,31 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import { Networkish } from '@ethersproject/networks';
+import { getLogger } from '@subql/node-core';
+import { BigNumber, constants } from 'ethers';
+import { JsonRpcProvider } from '../json-rpc-provider';
+import { ConnectionInfo } from '../web';
+
+const logger = getLogger('celo-provider');
+
+export class CeloJsonRpcProvider extends JsonRpcProvider {
+  private flanHardForkBlock = BigNumber.from('16068685');
+  constructor(url?: ConnectionInfo | string, network?: Networkish) {
+    super(url, network);
+
+    const originalBlockFormatter = this.formatter._block;
+    this.formatter._block = (value, format) => {
+      return originalBlockFormatter(
+        {
+          gasLimit:
+            BigNumber.from(value.number) < this.flanHardForkBlock
+              ? constants.Zero
+              : value.gasLimit,
+          ...value,
+        },
+        format,
+      );
+    };
+  }
+}

--- a/packages/node/src/ethereum/ethers/celo/celo-ws-provider.spec.ts
+++ b/packages/node/src/ethereum/ethers/celo/celo-ws-provider.spec.ts
@@ -1,0 +1,36 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import { BigNumber, constants, utils } from 'ethers';
+import { formatBlock } from '../../utils.ethereum';
+import { CeloWsProvider } from './celo-ws-provider';
+
+describe('CeloJsonRpcProvider', () => {
+  let provider: CeloWsProvider;
+
+  beforeEach(() => {
+    provider = new CeloWsProvider('https://forno.celo.org');
+  });
+
+  // Test if gasLimit is correctly set for blocks before the hard fork
+  it('should set gasLimit to zero for blocks before the hard fork', async () => {
+    const block = formatBlock(
+      await provider.send('eth_getBlockByNumber', [
+        utils.hexValue(16068684),
+        true,
+      ]),
+    );
+    expect(BigNumber.from(block.gasLimit)).toEqual(constants.Zero);
+  });
+
+  // Test if gasLimit is correctly set for blocks after the hard fork
+  it('should not set gasLimit to zero for blocks after the hard fork', async () => {
+    const block = formatBlock(
+      await provider.send('eth_getBlockByNumber', [
+        utils.hexValue(21055596),
+        true,
+      ]),
+    );
+    expect(BigNumber.from(block.gasLimit)).toEqual(BigNumber.from(0x1312d00));
+  });
+});

--- a/packages/node/src/ethereum/ethers/celo/celo-ws-provider.ts
+++ b/packages/node/src/ethereum/ethers/celo/celo-ws-provider.ts
@@ -1,0 +1,30 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import { Networkish } from '@ethersproject/networks';
+import { WebSocketProvider } from '@ethersproject/providers';
+import { getLogger } from '@subql/node-core';
+import { BigNumber, constants } from 'ethers';
+
+const logger = getLogger('celo-ws-provider');
+
+export class CeloWsProvider extends WebSocketProvider {
+  private flanHardForkBlock = BigNumber.from('16068685');
+  constructor(url?: string, network?: Networkish) {
+    super(url, network);
+
+    const originalBlockFormatter = this.formatter._block;
+    this.formatter._block = (value, format) => {
+      return originalBlockFormatter(
+        {
+          gasLimit:
+            BigNumber.from(value.number) < this.flanHardForkBlock
+              ? constants.Zero
+              : value.gasLimit,
+          ...value,
+        },
+        format,
+      );
+    };
+  }
+}

--- a/packages/node/src/ethereum/utils.ethereum.ts
+++ b/packages/node/src/ethereum/utils.ethereum.ts
@@ -33,6 +33,9 @@ function handleNumber(value: string | number): BigNumber {
   if (value === '0x') {
     return Zero;
   }
+  if (value === null) {
+    return Zero;
+  }
   return BigNumber.from(value);
 }
 


### PR DESCRIPTION
# Description
Prior to the Flan hard fork, celo was not compatible with ether.js. We need a custom formatter with JsonRpcProvider to handle blocks before the Flan hard fork that happened at block 16068685

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
