### PR TITLE
Fix address filter warning

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix warning for filter address
+
 ## [2.12.3] - 2023-09-04
 ### Fixed
 - lock to `@subql/common` 2.6.0, in order to fix unknown reader issue. (#152)

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Fix warning for filter address
+- Fix warning for filter address (#154)
 
 ## [2.12.3] - 2023-09-04
 ### Fixed

--- a/packages/node/src/indexer/fetch.service.spec.ts
+++ b/packages/node/src/indexer/fetch.service.spec.ts
@@ -241,6 +241,84 @@ describe('Dictionary queries', () => {
         },
       ]);
     });
+
+    it('If ds option provide contract address, it should use ds options "address" ', () => {
+      const ds: SubqlRuntimeDatasource = {
+        kind: EthereumDatasourceKind.Runtime,
+        assets: new Map(),
+        options: {
+          abi: 'erc20',
+          address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
+        },
+        startBlock: 1,
+        mapping: {
+          file: '',
+          handlers: [
+            {
+              handler: 'handleTransfer',
+              kind: EthereumHandlerKind.Call,
+              filter: {
+                function: 'approve(address spender, uint256 rawAmount)',
+              },
+            },
+          ],
+        },
+      };
+
+      const result = buildDictionaryQueryEntries([ds], 1);
+      expect(result).toEqual([
+        {
+          entity: 'evmTransactions',
+          conditions: [
+            {
+              field: 'to',
+              matcher: 'equalTo',
+              value: '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619',
+            },
+            { field: 'func', matcher: 'equalTo', value: '0x095ea7b3' },
+          ],
+        },
+      ]);
+    });
+
+    it('If filter  provide contract address, it should use filter "to" ', () => {
+      const ds: SubqlRuntimeDatasource = {
+        kind: EthereumDatasourceKind.Runtime,
+        assets: new Map(),
+        options: {
+          abi: 'erc20',
+        },
+        startBlock: 1,
+        mapping: {
+          file: '',
+          handlers: [
+            {
+              handler: 'handleTransfer',
+              kind: EthereumHandlerKind.Call,
+              filter: {
+                to: '0xabcde',
+                function: 'approve(address spender, uint256 rawAmount)',
+              },
+            },
+          ],
+        },
+      };
+
+      const result = buildDictionaryQueryEntries([ds], 1);
+      expect(result).toEqual([
+        {
+          entity: 'evmTransactions',
+          conditions: [
+            {
+              field: 'to',
+              matcher: 'equalTo',
+              value: '0xabcde',
+            },
+            { field: 'func', matcher: 'equalTo', value: '0x095ea7b3' },
+          ],
+        },
+      ]);
+    });
   });
   describe('Correct dictionary query with dynamic ds', () => {
     it('Build correct erc1155 transfer single query', () => {

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -144,7 +144,7 @@ function callFilterToQueryEntry(
         matcher: 'isNull',
       });
     }
-  } else {
+  } else if (optionsAddresses && (filter.to || filter.to === null)) {
     logger.warn(
       `TransactionFilter 'to' conflict with 'address' in data source options`,
     );


### PR DESCRIPTION
# Description

Even only "address" provided in ds option, it still log warning like 

![image](https://github.com/subquery/subql-ethereum/assets/10431657/8caa78f3-da9f-491b-9c7c-5cc9605efc4b)

It should only warning when "address" and "to" in filter both exist. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
