### PR TITLE
Switch to getting logs via block hash instead of block number

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fetching logs via block height resulting in invalid results. Block hash is now used to ensure correct results. (#156)
 
 ## [2.12.1] - 2023-09-01
 ### Fixed
@@ -15,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fallback to singular provider if batch provider is not supported (#144)
 - Fix missing ds option for event in dictionary query entries (#145)
 - Update `node-core` to 4.2.5, fix dictionary failed to get token issue.
+
 ### Added
 - Custom provider for Celo (#147)
 
@@ -27,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.10.0] - 2023-07-31
 ### Added
 - Added `!null` filter for logs (#135)
+
 ### Changed
 - Update license to GPL-3.0 (#137)
 - Updated retry logic for eth requests (#134)

--- a/packages/node/src/ethereum/api.ethereum.ts
+++ b/packages/node/src/ethereum/api.ethereum.ts
@@ -265,13 +265,8 @@ export class EthereumApi implements ApiWrapper<EthereumBlockWrapper> {
     includeTx?: boolean,
   ): Promise<EthereumBlockWrapped> {
     try {
-      const [block, logs] = await Promise.all([
-        this.getBlockPromise(blockNumber, includeTx),
-        this.client.getLogs({
-          fromBlock: hexValue(blockNumber),
-          toBlock: hexValue(blockNumber),
-        }),
-      ]);
+      const block = await this.getBlockPromise(blockNumber, includeTx);
+      const logs = await this.client.getLogs({ blockHash: block.hash });
 
       const ret = new EthereumBlockWrapped(
         block,


### PR DESCRIPTION
# Description
Using the block height to get logs will always return results or empty results rather than an invalid result. Switching to using the block hash guarantees we get the right logs for the block. If an endpoint is out of sync and we're unable to get the logs then retry logic will handle it.

Fixes https://github.com/subquery/subql/issues/1999
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
