### PR TITLE
Add assertion that logs have a matching block

### DIFF
--- a/packages/node/src/ethereum/block.ethereum.ts
+++ b/packages/node/src/ethereum/block.ethereum.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import assert from 'node:assert';
 import {
   EthereumBlock,
   EthereumTransactionFilter,
@@ -30,7 +31,7 @@ export class EthereumBlockWrapped implements EthereumBlockWrapper {
     this._logs.forEach((l) => {
       const tx = this._txs.find((tx) => tx.hash === l.transactionHash);
 
-      if (!tx) return;
+      assert(tx, `Unable to match log to transaction ${l.transactionHash}`);
       tx.logs = tx.logs ? [...tx.logs, l] : [l];
     });
   }


### PR DESCRIPTION
Asserts that a log has a matching transaction. This should always be the case but rather than silently fail it would be detected.

This helps when it comes to indexing the block as we iterate on the logs within each transaction