### PR TITLE
[release] 20231005

### DIFF
--- a/packages/common-ethereum/CHANGELOG.md
+++ b/packages/common-ethereum/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.2] - 2023-10-05
+### Changed
+- Version bump with `@subql/types-ethereum` 3.0.2
+
 ## [3.0.1] - 2023-10-04
 ### Changed
 - Version bump with `@subql/common` 3.1.1
@@ -85,7 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sync with main sdk (#14)
 
 ## [0.1.0] - 2022-10-31
-[Unreleased]: https://github.com/subquery/subql-ethereum/compare/common-ethereum/3.0.1...HEAD
+[Unreleased]: https://github.com/subquery/subql-ethereum/compare/common-ethereum/3.0.2...HEAD
+[3.0.2]: https://github.com/subquery/subql-ethereum/compare/common-ethereum/3.0.1...common-ethereum/3.0.2
 [3.0.1]: https://github.com/subquery/subql-ethereum/compare/common-ethereum/3.0.0...common-ethereum/3.0.1
 [3.0.0]: https://github.com/subquery/subql-ethereum/compare/common-ethereum/2.3.0...common-ethereum/3.0.0
 [2.3.0]: https://github.com/subquery/subql-ethereum/compare/common-ethereum/2.2.5...common-ethereum/2.3.0

--- a/packages/common-ethereum/package.json
+++ b/packages/common-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subql/common-ethereum",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "",
   "scripts": {
     "build": "rm -rf dist && tsc -b",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.3] - 2023-10-05
+### Changed
+- Version bump with `@subql/types-ethereum` 3.0.2
+
 ## [3.0.2] - 2023-10-04
 ### Fixed
 - Fix reindex service without poi feature with `node-core`
@@ -260,7 +264,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Init release
 
-[Unreleased]: https://github.com/subquery/subql-ethereum/compare/node-ethereum/3.0.2...HEAD
+[Unreleased]: https://github.com/subquery/subql-ethereum/compare/node-ethereum/3.0.3...HEAD
+[3.0.3]: https://github.com/subquery/subql-ethereum/compare/node-ethereum/3.0.2...node-ethereum/3.0.3
 [3.0.2]: https://github.com/subquery/subql-ethereum/compare/node-ethereum/3.0.1...node-ethereum/3.0.2
 [3.0.1]: https://github.com/subquery/subql-ethereum/compare/node-ethereum/3.0.0...node-ethereum/3.0.1
 [3.0.0]: https://github.com/subquery/subql-ethereum/compare/node-ethereum/2.12.5...node-ethereum/3.0.0

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subql/node-ethereum",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "",
   "author": "Ian He",
   "license": "GPL-3.0",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.0.2] - 2023-10-05
 ### Fixed
 - Fixed RuntimeDatasourceTemplate's generic typing (#177)
 
@@ -73,7 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sync with main sdk (#14)
 
 ## [0.1.0] - 2022-10-31
-[Unreleased]: https://github.com/subquery/subql-ethereum/compare/types/3.0.1...HEAD
+[Unreleased]: https://github.com/subquery/subql-ethereum/compare/types/3.0.2...HEAD
+[3.0.2]: https://github.com/subquery/subql-ethereum/compare/types/3.0.1...types/3.0.2
 [3.0.1]: https://github.com/subquery/subql-ethereum/compare/types/3.0.0...types/3.0.1
 [3.0.0]: https://github.com/subquery/subql-ethereum/compare/types/2.2.5...types/3.0.0
 [2.2.5]: https://github.com/subquery/subql-ethereum/compare/types/2.2.4...types/2.2.5

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subql/types-ethereum",
-  "version": "3.0.2-0",
+  "version": "3.0.2",
   "description": "",
   "homepage": "https://github.com/subquery/subql",
   "repository": "github:subquery/subql",
@@ -18,6 +18,5 @@
   "dependencies": {
     "@ethersproject/abstract-provider": "^5.6.1",
     "@subql/types-core": "0.1.1"
-  },
-  "stableVersion": "3.0.1"
+  }
 }


### PR DESCRIPTION
Release for
- Fix on `subql/types-ethereum` on type-ethereum
- bump  `subql/types-ethereum` on node-ethereum
- bump  `subql/types-ethereum` on common-ethereum