### PR TITLE
Skip using safe tag for cronos

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Unfinalized blocks not working with Cronos (#193)
 
 ## [3.1.1] - 2023-10-25
 ### Fixed

--- a/packages/node/src/ethereum/api.ethereum.ts
+++ b/packages/node/src/ethereum/api.ethereum.ts
@@ -223,7 +223,9 @@ export class EthereumApi implements ApiWrapper {
   }
 
   async getBestBlockHeight(): Promise<number> {
-    const tag = this.supportsFinalization ? 'safe' : 'latest';
+    // Cronos "safe" tag doesn't currently work as indended
+    const tag =
+      this.supportsFinalization && this.chainId !== 25 ? 'safe' : 'latest';
     return (await this.client.getBlock(tag)).number;
   }
 


### PR DESCRIPTION
# Description
Cronos RPC supports "safe" tag but returns block number 1. If unfinalized blocks is enabled this leads to indexing not happening because there are no blocks to index.

This adds an exlusion from using the "safe" tag on cronos

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
