### PR TITLE
Fix transaction getter being removed when cloning object

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Getting transaction receipts when accessing via a log handler
+- transaction missing from log (#202)
 
 ## [3.3.0] - 2023-11-06
 ### Added

--- a/packages/node/src/ethereum/api.ethereum.test.ts
+++ b/packages/node/src/ethereum/api.ethereum.test.ts
@@ -73,6 +73,10 @@ describe('Api.ethereum', () => {
   it('should have the ability to get receipts via transactions from all types', () => {
     expect(typeof blockData.transactions[0].receipt).toEqual('function');
     expect(typeof blockData.logs[0].transaction.receipt).toEqual('function');
+    expect(typeof blockData.logs[0].transaction.from).toEqual('string');
+    expect(typeof blockData.transactions[81].logs[0].transaction.from).toEqual(
+      'string',
+    );
     expect(
       typeof blockData.transactions[81].logs[0].transaction.receipt,
     ).toEqual('function');
@@ -89,6 +93,17 @@ describe('Api.ethereum', () => {
     expect(parsedTx.logs[0].args).toBeTruthy();
   });
 
+  it('Should decode transaction data and not clone object', async () => {
+    const tx = blockData.transactions.find(
+      (e) =>
+        e.hash ===
+        '0x8e419d0e36d7f9c099a001fded516bd168edd9d27b4aec2bcd56ba3b3b955ccc',
+    );
+    const parsedTx = await ethApi.parseTransaction(tx, ds);
+
+    expect(parsedTx).toBe(tx);
+  });
+
   it('Should return raw logs, if decode fails', async () => {
     // not Erc721
     const tx = blockData.transactions.find(
@@ -99,6 +114,18 @@ describe('Api.ethereum', () => {
     const parsedLog = await ethApi.parseLog(tx.logs[0], ds);
     expect(parsedLog).not.toHaveProperty('args');
     expect(parsedLog).toBeTruthy();
+  });
+
+  // This test is here to ensure getters aren't removed
+  it('Should not clone logs when parsing args', async () => {
+    const log = blockData.transactions.find(
+      (e) =>
+        e.hash ===
+        '0x8e419d0e36d7f9c099a001fded516bd168edd9d27b4aec2bcd56ba3b3b955ccc',
+    ).logs[1];
+
+    const parsedLog = await ethApi.parseLog(log, ds);
+    expect(parsedLog).toBe(log);
   });
 
   it('Null filter support', async () => {

--- a/packages/node/src/ethereum/api.ethereum.ts
+++ b/packages/node/src/ethereum/api.ethereum.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import assert from 'assert';
 import fs from 'fs';
 import http from 'http';
 import https from 'https';
@@ -382,10 +383,10 @@ export class EthereumApi implements ApiWrapper {
         return log;
       }
       const iface = this.buildInterface(ds.options.abi, await loadAssets(ds));
-      return {
-        ...log,
-        args: iface?.parseLog(log).args as T,
-      };
+
+      log.args = iface?.parseLog(log).args as T;
+
+      return log;
     } catch (e) {
       logger.warn(`Failed to parse log data: ${e.message}`);
       return log;
@@ -412,10 +413,9 @@ export class EthereumApi implements ApiWrapper {
           transaction.logs.map(async (log) => this.parseLog(log, ds)),
         )) as Array<EthereumLog | EthereumLog<T>>);
 
-      return {
-        ...transaction,
-        args,
-      };
+      transaction.args = args;
+
+      return transaction;
     } catch (e) {
       logger.warn(`Failed to parse transaction data: ${e.message}`);
       return transaction;


### PR DESCRIPTION
# Description
Fixes transaction missing on log object because it was cloning the object and removing the getter function

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
