### PR TITLE
Bring back block confirmations arg that was removed in #210

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `block-confirmations` arg being removed in recent sync with main SDK (#213)
 
 ## [3.3.4] - 2023-11-16
 ### Fixed
@@ -12,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.3.3] - 2023-11-13
 ### Changed
-- Updates to match changes in 
+- Updates to match changes in `@subql/node-core` (#210)
   - Dictionary service to use dictionary registry
   - Use yargs from node core
 

--- a/packages/node/src/yargs.ts
+++ b/packages/node/src/yargs.ts
@@ -22,4 +22,13 @@ export const yargsOptions = yargsBuilder({
     const { reindexInit } = require('./subcommands/reindex.init');
     return reindexInit(targetHeight);
   },
+  runOptions: {
+    'block-confirmations': {
+      demandOption: false,
+      default: 20,
+      describe:
+        'The number of blocks behind the head to be considered finalized, this has no effect with Ethereum',
+      type: 'number',
+    },
+  },
 });


### PR DESCRIPTION
# Description
Bring back block-confirmations arg that was accidentally removed in sync with main sdk

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
## Checklist

- [ ] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
