### PR TITLE
Update ethereum address validation to include Zilliqa address

### DIFF
--- a/packages/common-ethereum/CHANGELOG.md
+++ b/packages/common-ethereum/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for Zilliqa addresses (#231)
 
 ## [3.1.2] - 2023-12-22
 ### Fixed

--- a/packages/common-ethereum/package.json
+++ b/packages/common-ethereum/package.json
@@ -17,6 +17,7 @@
     "@subql/common": "^3.3.1",
     "@subql/types-ethereum": "workspace:*",
     "@typechain/ethers-v5": "^11.1.1",
+    "@zilliqa-js/crypto": "^3.5.0",
     "js-yaml": "^4.1.0",
     "pino": "^6.13.3",
     "reflect-metadata": "^0.1.13",

--- a/packages/common-ethereum/src/project/models.ts
+++ b/packages/common-ethereum/src/project/models.ts
@@ -35,6 +35,7 @@ import {
   ValidationArguments,
 } from 'class-validator';
 import {SubqlEthereumDatasourceKind, SubqlEthereumHandlerKind, SubqlEthereumProcessorOptions} from './types';
+import {IsEthereumOrZilliqaAddress} from './utils';
 
 export class BlockFilter implements EthereumBlockFilter {
   @IsOptional()
@@ -176,7 +177,7 @@ export class EthereumProcessorOptions implements SubqlEthereumProcessorOptions {
   @IsString()
   abi?: string;
   @IsOptional()
-  @IsEthereumAddress()
+  @IsEthereumOrZilliqaAddress()
   address?: string;
 }
 

--- a/packages/common-ethereum/src/project/utils.spec.ts
+++ b/packages/common-ethereum/src/project/utils.spec.ts
@@ -1,0 +1,22 @@
+// Copyright 2020-2023 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {isEthereumOrZilliqaAddress} from './utils';
+
+describe('Project Utils', () => {
+  it('can validate Ethereum and Zilliqa addresses', () => {
+    // Ethereum addresses
+    expect(isEthereumOrZilliqaAddress('0x0000000000000000000000000000000000000000')).toBeTruthy();
+    expect(isEthereumOrZilliqaAddress('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48')).toBeTruthy();
+
+    // Zilliqa addresses
+    expect(isEthereumOrZilliqaAddress('0x7Aa7eA9f4534d8D70224b9c2FB165242F321F12b')).toBeTruthy();
+    expect(isEthereumOrZilliqaAddress('zil102n74869xnvdwq3yh8p0k9jjgtejruft268tg8')).toBeTruthy();
+
+    // Invalid addresses
+    expect(isEthereumOrZilliqaAddress('')).toBeFalsy();
+    expect(isEthereumOrZilliqaAddress('hello world')).toBeFalsy();
+    expect(isEthereumOrZilliqaAddress('zil1')).toBeFalsy();
+    expect(isEthereumOrZilliqaAddress('0x0')).toBeFalsy();
+  });
+});

--- a/packages/common-ethereum/src/project/utils.ts
+++ b/packages/common-ethereum/src/project/utils.ts
@@ -9,6 +9,8 @@ import {
   EthereumHandlerKind,
   SubqlRuntimeDatasource,
 } from '@subql/types-ethereum';
+import {fromBech32Address} from '@zilliqa-js/crypto';
+import {buildMessage, isEthereumAddress, ValidateBy, ValidationOptions} from 'class-validator';
 
 export function isBlockHandlerProcessor<E>(
   hp: SecondLayerHandlerProcessor<EthereumHandlerKind, unknown, unknown>
@@ -34,4 +36,29 @@ export function isCustomDs(ds: SubqlDatasource): ds is SubqlCustomDatasource<str
 
 export function isRuntimeDs(ds: SubqlDatasource): ds is SubqlRuntimeDatasource {
   return ds.kind === EthereumDatasourceKind.Runtime;
+}
+
+export function isEthereumOrZilliqaAddress(address: string): boolean {
+  try {
+    const ethFormat = fromBech32Address(address);
+    return isEthereumAddress(ethFormat);
+  } catch (e) {
+    return isEthereumAddress(address);
+  }
+}
+
+export function IsEthereumOrZilliqaAddress(validationOptions?: ValidationOptions): PropertyDecorator {
+  return ValidateBy(
+    {
+      name: 'isEthereumOrZilliqaAddress',
+      validator: {
+        validate: (value, args): boolean => isEthereumOrZilliqaAddress(value),
+        defaultMessage: buildMessage(
+          (eachPrefix) => `${eachPrefix}$property must be a Zilliqa address`,
+          validationOptions
+        ),
+      },
+    },
+    validationOptions
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3293,6 +3293,7 @@ __metadata:
     "@types/lodash": ^4
     "@types/pino": ^6.3.12
     "@types/rimraf": 3.0.2
+    "@zilliqa-js/crypto": ^3.5.0
     ejs: 3.1.7
     js-yaml: ^4.1.0
     lodash: 4.17.21
@@ -4355,6 +4356,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@zilliqa-js/crypto@npm:^3.5.0":
+  version: 3.5.0
+  resolution: "@zilliqa-js/crypto@npm:3.5.0"
+  dependencies:
+    "@zilliqa-js/util": 3.5.0
+    aes-js: ^3.1.1
+    buffer: ^6.0.3
+    crypto-js: ^4.2.0
+    elliptic: ^6.5.0
+    hash.js: ^1.1.5
+    hmac-drbg: ^1.0.1
+    pbkdf2: ^3.0.16
+    scrypt-js: ^3.0.1
+    scryptsy: ^2.1.0
+    tslib: 2.3.1
+    uuid: 8.3.2
+  checksum: 3fdbe49f5d02382d6496dd2579295d63fac0fb45206f95b77ff0c723ee56f1fd62ecf2150883e8d6b3e0023694d9e20ebf14eb82b01614d8dd540af754a2f3b4
+  languageName: node
+  linkType: hard
+
+"@zilliqa-js/util@npm:3.5.0":
+  version: 3.5.0
+  resolution: "@zilliqa-js/util@npm:3.5.0"
+  dependencies:
+    bn.js: ^4.11.8
+    camelcase: ^5.0.0
+    long: ^4.0.0
+    tslib: 2.3.1
+  checksum: 2df9c17873e9d6867e8f335592cfc5381d58ff6f040d0851f0e6dc9b8b02131a97f3f5aa62cae93639c7fc82cb6900f262dd341d88492daa2880a601f6224968
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:1, abbrev@npm:^1.0.0":
   version: 1.1.1
   resolution: "abbrev@npm:1.1.1"
@@ -4415,6 +4448,13 @@ __metadata:
   version: 3.0.0
   resolution: "aes-js@npm:3.0.0"
   checksum: 251e26d533cd1a915b44896b17d5ed68c24a02484cfdd2e74ec700a309267db96651ea4eb657bf20aac32a3baa61f6e34edf8e2fec2de440a655da9942d334b8
+  languageName: node
+  linkType: hard
+
+"aes-js@npm:^3.1.1":
+  version: 3.1.2
+  resolution: "aes-js@npm:3.1.2"
+  checksum: 062154d50b1e433cc8c3b8ca7879f3a6375d5e79c2a507b2b6c4ec920b4cd851bf2afa7f65c98761a9da89c0ab618cbe6529e8e9a1c71f93290b53128fb8f712
   languageName: node
   linkType: hard
 
@@ -5062,7 +5102,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^4.11.9, bn.js@npm:^4.12.0":
+"bn.js@npm:^4.11.8, bn.js@npm:^4.11.9, bn.js@npm:^4.12.0":
   version: 4.12.0
   resolution: "bn.js@npm:4.12.0"
   checksum: 39afb4f15f4ea537b55eaf1446c896af28ac948fdcf47171961475724d1bb65118cca49fa6e3d67706e4790955ec0e74de584e45c8f1ef89f46c812bee5b5a12
@@ -5373,7 +5413,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^5.3.1":
+"camelcase@npm:^5.0.0, camelcase@npm:^5.3.1":
   version: 5.3.1
   resolution: "camelcase@npm:5.3.1"
   checksum: e6effce26b9404e3c0f301498184f243811c30dfe6d0b9051863bd8e4034d09c8c2923794f280d6827e5aa055f6c434115ff97864a16a963366fb35fd673024b
@@ -5935,6 +5975,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"crypto-js@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "crypto-js@npm:4.2.0"
+  checksum: f051666dbc077c8324777f44fbd3aaea2986f198fe85092535130d17026c7c2ccf2d23ee5b29b36f7a4a07312db2fae23c9094b644cc35f7858b1b4fcaf27774
+  languageName: node
+  linkType: hard
+
 "crypto-random-string@npm:^2.0.0":
   version: 2.0.0
   resolution: "crypto-random-string@npm:2.0.0"
@@ -6275,7 +6322,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:6.5.4, elliptic@npm:^6.5.4":
+"elliptic@npm:6.5.4, elliptic@npm:^6.5.0, elliptic@npm:^6.5.4":
   version: 6.5.4
   resolution: "elliptic@npm:6.5.4"
   dependencies:
@@ -7792,7 +7839,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hash.js@npm:1.1.7, hash.js@npm:^1.0.0, hash.js@npm:^1.0.3, hash.js@npm:^1.1.7":
+"hash.js@npm:1.1.7, hash.js@npm:^1.0.0, hash.js@npm:^1.0.3, hash.js@npm:^1.1.5, hash.js@npm:^1.1.7":
   version: 1.1.7
   resolution: "hash.js@npm:1.1.7"
   dependencies:
@@ -10846,7 +10893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pbkdf2@npm:^3.0.17":
+"pbkdf2@npm:^3.0.16, pbkdf2@npm:^3.0.17":
   version: 3.1.2
   resolution: "pbkdf2@npm:3.1.2"
   dependencies:
@@ -11797,10 +11844,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scrypt-js@npm:3.0.1, scrypt-js@npm:^3.0.0":
+"scrypt-js@npm:3.0.1, scrypt-js@npm:^3.0.0, scrypt-js@npm:^3.0.1":
   version: 3.0.1
   resolution: "scrypt-js@npm:3.0.1"
   checksum: b7c7d1a68d6ca946f2fbb0778e0c4ec63c65501b54023b2af7d7e9f48fdb6c6580d6f7675cd53bda5944c5ebc057560d5a6365079752546865defb3b79dea454
+  languageName: node
+  linkType: hard
+
+"scryptsy@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "scryptsy@npm:2.1.0"
+  checksum: 46eee33a59895fbdc920da97446572083667512d8408548cc0d5f190eb4b84aa5d75a4bc8d0495530ff6a62d980497c72eb6fe8e6ab9c26aaa3d4dacb7954d08
   languageName: node
   linkType: hard
 
@@ -12783,6 +12837,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:2.3.1":
+  version: 2.3.1
+  resolution: "tslib@npm:2.3.1"
+  checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9
+  languageName: node
+  linkType: hard
+
 "tslib@npm:2.5.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0":
   version: 2.5.3
   resolution: "tslib@npm:2.5.3"
@@ -13315,21 +13376,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:8.3.2, uuid@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
 "uuid@npm:9.0.0":
   version: 9.0.0
   resolution: "uuid@npm:9.0.0"
   bin:
     uuid: dist/bin/uuid
   checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
Update validation of filter addresses to support zilliqa addresses which use a different format to ethereum.

Fixes https://github.com/subquery/subql/issues/1996

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
