### PR TITLE
Add the ability to filter for native transfers

### DIFF
--- a/packages/common-ethereum/CHANGELOG.md
+++ b/packages/common-ethereum/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Transaction filter function field can now be null (#243)
 
 ## [3.2.0] - 2024-01-08
 ### Added

--- a/packages/common-ethereum/src/project/models.ts
+++ b/packages/common-ethereum/src/project/models.ts
@@ -61,7 +61,7 @@ export class TransactionFilter implements EthereumTransactionFilter {
   to?: string;
   @IsOptional()
   @IsString()
-  function?: string;
+  function?: string | null;
 }
 
 export function forbidNonWhitelisted(keys: any, validationOptions?: ValidationOptions) {

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- The ability to filter transactions with no input data (#243)
 
 ## [3.7.0] - 2024-01-30
 ### Added

--- a/packages/node/src/ethereum/api.ethereum.test.ts
+++ b/packages/node/src/ethereum/api.ethereum.test.ts
@@ -187,6 +187,33 @@ describe('Api.ethereum', () => {
     expect(erc721Transfers.length).toBe(2);
   });
 
+  it('Null and 0x (empty) filter support for transaction data', async () => {
+    const beamEndpoint = 'https://mainnet.base.org/';
+    ethApi = new EthereumApi(beamEndpoint, BLOCK_CONFIRMATIONS, eventEmitter);
+    await ethApi.init();
+    blockData = await fetchBlock(1104962);
+    // blockData.transactions[0].to = undefined;
+    const result = blockData.transactions.filter((tx) => {
+      if (filterTransactionsProcessor(tx, { function: null })) {
+        return tx.hash;
+      }
+    });
+    expect(result.length).toBe(1);
+    expect(result[0].hash).toBe(
+      '0x182c5381f8fa3332a7bd676b1c819a15119972db52bd5210afead88f18fff642',
+    );
+
+    const result2 = blockData.transactions.filter((tx) => {
+      if (filterTransactionsProcessor(tx, { function: '0x' })) {
+        return tx.hash;
+      }
+    });
+    expect(result2.length).toBe(1);
+    expect(result2[0].hash).toBe(
+      '0x182c5381f8fa3332a7bd676b1c819a15119972db52bd5210afead88f18fff642',
+    );
+  });
+
   it('Null filter support, for undefined transaction.to', async () => {
     const beamEndpoint = 'https://rpc.api.moonbeam.network';
     ethApi = new EthereumApi(beamEndpoint, BLOCK_CONFIRMATIONS, eventEmitter);

--- a/packages/node/src/ethereum/api.ethereum.ts
+++ b/packages/node/src/ethereum/api.ethereum.ts
@@ -421,7 +421,9 @@ export class EthereumApi implements ApiWrapper {
   ): Promise<EthereumTransaction<T> | EthereumTransaction> {
     try {
       if (!ds?.options?.abi) {
-        logger.warn('No ABI provided for datasource');
+        if (transaction.input !== '0x') {
+          logger.warn('No ABI provided for datasource');
+        }
         return transaction;
       }
       const assets = await loadAssets(ds);

--- a/packages/node/src/ethereum/block.ethereum.ts
+++ b/packages/node/src/ethereum/block.ethereum.ts
@@ -87,12 +87,17 @@ export function filterTransactionsProcessor(
   ) {
     return false;
   }
-  if (
-    filter.function &&
+  if (filter.function === null || filter.function === '0x') {
+    if (transaction.input !== '0x') {
+      return false;
+    }
+  } else if (
+    filter.function !== undefined &&
     transaction.input.indexOf(functionToSighash(filter.function)) !== 0
   ) {
     return false;
   }
+
   return true;
 }
 

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -152,13 +152,20 @@ function callFilterToQueryEntry(
     );
   }
 
-  if (filter.function) {
+  if (filter.function === null || filter.function === '0x') {
+    conditions.push({
+      field: 'func',
+      value: true,
+      matcher: 'isNull',
+    });
+  } else if (filter.function) {
     conditions.push({
       field: 'func',
       value: functionToSighash(filter.function),
       matcher: 'equalTo',
     });
   }
+
   return {
     entity: 'evmTransactions',
     conditions,
@@ -186,7 +193,7 @@ export function buildDictionaryQueryEntries(
           if (
             filter.from !== undefined ||
             filter.to !== undefined ||
-            filter.function
+            filter.function !== undefined
           ) {
             queryEntries.push(callFilterToQueryEntry(filter, ds.options));
           } else {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -5,9 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Fixed
 - Fix Eth datasource miss extend base datasource type, missing `endBlock` in Datasource
+
+### Added
+- Transaction filter function field can now be null (#243)
 
 ## [3.2.1] - 2023-11-30
 ### Changed

--- a/packages/types/src/ethereum/interfaces.ts
+++ b/packages/types/src/ethereum/interfaces.ts
@@ -27,8 +27,12 @@ export interface EthereumTransactionFilter {
    * The function sighash or function signature of the call. This is the first 32bytes of the data field
    * @example
    * function: 'setminimumStakingAmount(uint256 amount)',
+   * @example
+   * function: null, // This will filter transactions that have no input
+   * @example
+   * function: '0x, // This will filter transactions that have no input
    * */
-  function?: string;
+  function?: string | null;
 }
 
 /**


### PR DESCRIPTION
# Description
Update transaction filters to support native transfers with no input data.

## Examples

```ts
          {
            kind: EthereumHandlerKind.Call,
            handler: "handleTransaction",
            filter: {
              function: "0x",
            },
          },
```


```ts
          {
            kind: EthereumHandlerKind.Call,
            handler: "handleTransaction",
            filter: {
              function: null,
            },
          },
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
