### PR TITLE
Add error handling for getting chain aliases

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - The ability to filter transactions with no input data (#243)
 
+### Fixed
+- Error handling for fetching dictionary chain aliases and switch to built in nodejs fetch (#247)
+
 ## [3.7.0] - 2024-01-30
 ### Added
 - Special support for BEVM Canary (#241)

--- a/packages/node/src/indexer/dictionary.service.spec.ts
+++ b/packages/node/src/indexer/dictionary.service.spec.ts
@@ -1,0 +1,21 @@
+// Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import { NodeConfig } from '@subql/node-core';
+import { DictionaryService } from './dictionary.service';
+
+describe('Dictionary service', () => {
+  it('Can resovle chain aliases', async () => {
+    const dictionary = await DictionaryService.create(
+      {
+        network: { chainId: '336', dictionary: 'https://foo.bar' } as any,
+      } as any,
+      new NodeConfig({} as any, true),
+      null,
+    );
+
+    expect((dictionary as any).chainId).toBe(
+      '0xf1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108',
+    );
+  });
+});


### PR DESCRIPTION
# Description
Add error handling for fetching chain aliases and switch to built in fetch from node-fetch, this should hopefully fix issues with HTTP_PROXY and HTTPS_PROXY node flags

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
