### PR TITLE
Add assertion on fetchBlock for mismatched blockHash

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add assertion on mismatched blockHash for getLogs and getBlocks (#252)
 
 ## [3.8.1] - 2024-03-01
 ### Fixed

--- a/packages/node/src/ethereum/api.ethereum.test.ts
+++ b/packages/node/src/ethereum/api.ethereum.test.ts
@@ -344,13 +344,13 @@ describe('Api.ethereum', () => {
     jest.spyOn(ethApi as any, 'getBlockPromise').mockResolvedValueOnce({
       hash: mockBlockHash,
       transactions: [],
-      // Add other necessary block properties here
     });
 
-    jest.spyOn((ethApi as any).client, 'getLogs').mockResolvedValueOnce([
-      { blockHash: mockIncorrectBlockHash, transactionHash: 'tx1' },
-      // Add more logs if necessary
-    ]);
+    jest
+      .spyOn((ethApi as any).client, 'getLogs')
+      .mockResolvedValueOnce([
+        { blockHash: mockIncorrectBlockHash, transactionHash: 'tx1' },
+      ]);
 
     await expect(ethApi.fetchBlock(mockBlockNumber)).rejects.toThrow(
       `Log BlockHash does not match block: ${mockBlockNumber}`,

--- a/packages/node/src/ethereum/api.ethereum.test.ts
+++ b/packages/node/src/ethereum/api.ethereum.test.ts
@@ -329,4 +329,31 @@ describe('Api.ethereum', () => {
 
     expect((ethApi as any).supportsFinalized).toBeFalsy();
   });
+  it('Assert blockHash on logs and block', async () => {
+    ethApi = new EthereumApi(
+      'https://rpc.ankr.com/xdc',
+      BLOCK_CONFIRMATIONS,
+      eventEmitter,
+    );
+    await ethApi.init();
+
+    const mockBlockNumber = 72194336;
+    const mockBlockHash = 'mockBlockHash';
+    const mockIncorrectBlockHash = 'mockIncorrectBlockHash';
+
+    jest.spyOn(ethApi as any, 'getBlockPromise').mockResolvedValueOnce({
+      hash: mockBlockHash,
+      transactions: [],
+      // Add other necessary block properties here
+    });
+
+    jest.spyOn((ethApi as any).client, 'getLogs').mockResolvedValueOnce([
+      { blockHash: mockIncorrectBlockHash, transactionHash: 'tx1' },
+      // Add more logs if necessary
+    ]);
+
+    await expect(ethApi.fetchBlock(mockBlockNumber)).rejects.toThrow(
+      `Log BlockHash does not match block: ${mockBlockNumber}`,
+    );
+  });
 });

--- a/packages/node/src/ethereum/api.ethereum.ts
+++ b/packages/node/src/ethereum/api.ethereum.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import assert from 'assert';
 import fs from 'fs';
 import http from 'http';
 import https from 'https';
@@ -304,6 +305,14 @@ export class EthereumApi implements ApiWrapper {
     try {
       const block = await this.getBlockPromise(blockNumber, true);
       const logsRaw = await this.client.getLogs({ blockHash: block.hash });
+
+      // Certain RPC may not accommodate for blockHash, and would return wrong logs
+      if (logsRaw.length) {
+        assert(
+          logsRaw.find((l) => l.blockHash === block.hash),
+          `Log BlockHash does not match block: ${blockNumber}`,
+        );
+      }
 
       block.logs = logsRaw.map((l) => formatLog(l, block));
       block.transactions = block.transactions.map((tx) => ({

--- a/packages/node/src/ethereum/api.ethereum.ts
+++ b/packages/node/src/ethereum/api.ethereum.ts
@@ -309,7 +309,7 @@ export class EthereumApi implements ApiWrapper {
       // Certain RPC may not accommodate for blockHash, and would return wrong logs
       if (logsRaw.length) {
         assert(
-          logsRaw.find((l) => l.blockHash === block.hash),
+          logsRaw.every((l) => l.blockHash === block.hash),
           `Log BlockHash does not match block: ${blockNumber}`,
         );
       }


### PR DESCRIPTION
# Description

Certain rpc do not support getLogs param blockHash, so in order to accomodate for that we must throw if the log's blockHash does not align with the blockHash

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
