### PR TITLE
Fix dictionary queries when there are block filters with modulos

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Dictionary v2 transactions query not including address (#281)
+- Dictionary v1 and v2 queries with modulo filters (#283)
 
 ### Changed
 - Improved error message if genesis block is null (#282)

--- a/packages/node/src/indexer/dictionary/v1/ethDictionaryV1.spec.ts
+++ b/packages/node/src/indexer/dictionary/v1/ethDictionaryV1.spec.ts
@@ -337,7 +337,54 @@ describe('buildDictionaryV1QueryEntries', () => {
         },
       ]);
     });
+
+    it('builds a filter when theres a block handler with modulo filter', () => {
+      const ds: SubqlRuntimeDatasource = {
+        kind: EthereumDatasourceKind.Runtime,
+        assets: new Map(),
+        options: {
+          abi: 'erc20',
+        },
+        startBlock: 1,
+        mapping: {
+          file: '',
+          handlers: [
+            {
+              handler: 'handleTransfer',
+              kind: EthereumHandlerKind.Call,
+              filter: {
+                to: '0xabcde',
+                function: 'approve(address spender, uint256 rawAmount)',
+              },
+            },
+            {
+              handler: 'handleBlock',
+              kind: EthereumHandlerKind.Block,
+              filter: {
+                modulo: 200,
+              },
+            },
+          ],
+        },
+      };
+
+      const result = buildDictionaryV1QueryEntries([ds]);
+      expect(result).toEqual([
+        {
+          entity: 'evmTransactions',
+          conditions: [
+            {
+              field: 'to',
+              matcher: 'equalTo',
+              value: '0xabcde',
+            },
+            { field: 'func', matcher: 'equalTo', value: '0x095ea7b3' },
+          ],
+        },
+      ]);
+    });
   });
+
   describe('Correct dictionary query with dynamic ds', () => {
     it('Build correct erc1155 transfer single query', () => {
       const ds: SubqlRuntimeDatasource = {

--- a/packages/node/src/indexer/dictionary/v1/ethDictionaryV1.ts
+++ b/packages/node/src/indexer/dictionary/v1/ethDictionaryV1.ts
@@ -7,6 +7,7 @@ import {
   DictionaryQueryEntry as DictionaryV1QueryEntry,
 } from '@subql/types-core';
 import {
+  EthereumBlockFilter,
   EthereumHandlerKind,
   EthereumLogFilter,
   EthereumTransactionFilter,
@@ -172,7 +173,10 @@ export function buildDictionaryV1QueryEntries(
 
       switch (handler.kind) {
         case EthereumHandlerKind.Block:
-          return [];
+          if (handler.filter.modulo === undefined) {
+            return [];
+          }
+          break;
         case EthereumHandlerKind.Call: {
           const filter = handler.filter as EthereumTransactionFilter;
           if (

--- a/packages/node/src/indexer/dictionary/v2/ethDictionaryV2.spec.ts
+++ b/packages/node/src/indexer/dictionary/v2/ethDictionaryV2.spec.ts
@@ -570,4 +570,45 @@ describe('buildDictionaryV2QueryEntry', () => {
       ],
     });
   });
+
+  it('builds a filter when theres a block handler with modulo filter', () => {
+    const ds: SubqlRuntimeDatasource = {
+      kind: EthereumDatasourceKind.Runtime,
+      assets: new Map(),
+      options: {
+        abi: 'erc20',
+        address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
+      },
+      startBlock: 1,
+      mapping: {
+        file: '',
+        handlers: [
+          {
+            handler: 'handleBlock',
+            kind: EthereumHandlerKind.Block,
+            filter: {
+              modulo: 100,
+            },
+          },
+          {
+            handler: 'handleTx',
+            kind: EthereumHandlerKind.Call,
+            filter: {
+              function: 'setminimumStakingAmount(uint256 amount)',
+            },
+          },
+        ],
+      },
+    };
+    const result = buildDictionaryV2QueryEntry([ds]);
+
+    expect(result).toEqual({
+      transactions: [
+        {
+          to: ['0x7ceb23fd6bc0add59e62ac25578270cff1b9f619'],
+          data: ['0x7ef9ea98'],
+        },
+      ],
+    });
+  });
 });

--- a/packages/node/src/indexer/dictionary/v2/types.ts
+++ b/packages/node/src/indexer/dictionary/v2/types.ts
@@ -66,8 +66,8 @@ export interface RawEthLog {
  * Eth dictionary RPC request filter conditions
  */
 export interface EthDictionaryV2QueryEntry extends DictionaryV2QueryEntry {
-  logs: EthDictionaryLogConditions[];
-  transactions: EthDictionaryTxConditions[];
+  logs?: EthDictionaryLogConditions[];
+  transactions?: EthDictionaryTxConditions[];
 }
 
 export interface EthDictionaryLogConditions {


### PR DESCRIPTION
# Description
- Fixes dictionary v1 query being empty for any block handler, now considers modulo filters
- Fixes dictionary v2 returning with a partial query if there were no filters and considers modulo filters

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
