### PR TITLE
Fix query params being stripped

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Endpoint search params being stripped (#301)
 
 ## [4.4.2] - 2024-06-06
 ### Fixed

--- a/packages/node/src/ethereum/api.ethereum.test.ts
+++ b/packages/node/src/ethereum/api.ethereum.test.ts
@@ -18,8 +18,7 @@ import {
 } from './block.ethereum';
 
 // Add api key to work
-// const HTTP_ENDPOINT = 'https://eth.api.onfinality.io/public';
-const HTTP_ENDPOINT = 'https://eth.llamarpc.com';
+const HTTP_ENDPOINT = 'https://ethereum.rpc.subquery.network/public';
 const BLOCK_CONFIRMATIONS = 20;
 
 const ds: SubqlRuntimeDatasource = {

--- a/packages/node/src/ethereum/api.ethereum.ts
+++ b/packages/node/src/ethereum/api.ethereum.ts
@@ -126,7 +126,7 @@ export class EthereumApi implements ApiWrapper {
     logger.info(`Api host: ${hostname}, method: ${protocolStr}`);
     if (protocolStr === 'https' || protocolStr === 'http') {
       const connection: ConnectionInfo = {
-        url: this.endpoint.split('?')[0],
+        url: this.endpoint,
         headers: {
           'User-Agent': `Subquery-Node ${packageVersion}`,
         },

--- a/packages/node/src/ethereum/api.service.ethereum.test.ts
+++ b/packages/node/src/ethereum/api.service.ethereum.test.ts
@@ -16,8 +16,7 @@ import { EthereumApiService } from './api.service.ethereum';
 
 // Add api key to work
 const WS_ENDPOINT = 'wss://eth.api.onfinality.io/ws?apikey=';
-// const HTTP_ENDPOINT = 'https://eth.api.onfinality.io/public';
-const HTTP_ENDPOINT = 'https://eth.llamarpc.com';
+const HTTP_ENDPOINT = 'https://ethereum.rpc.subquery.network/public';
 
 function testSubqueryProject(endpoint: string): SubqueryProject {
   return {

--- a/packages/node/src/ethereum/api.service.ethereum.ts
+++ b/packages/node/src/ethereum/api.service.ethereum.ts
@@ -57,10 +57,7 @@ export class EthereumApiService extends ApiService<
     try {
       network = this.project.network;
     } catch (e) {
-      exitWithError(
-        new Error(`Failed to init api`, { cause: Object.keys(e) }),
-        logger,
-      );
+      exitWithError(new Error(`Failed to init api`, { cause: e }), logger);
     }
 
     const endpoints = Array.isArray(network.endpoint)

--- a/packages/node/src/indexer/dictionary/v1/ethDictionaryV1.spec.ts
+++ b/packages/node/src/indexer/dictionary/v1/ethDictionaryV1.spec.ts
@@ -17,8 +17,6 @@ import {
   EthDictionaryV1,
 } from './ethDictionaryV1';
 
-// const HTTP_ENDPOINT = 'https://eth.api.onfinality.io/public';
-const HTTP_ENDPOINT = 'https://eth.llamarpc.com';
 const mockTempDs: EthereumProjectDsTemplate[] = [
   {
     name: 'ERC721',

--- a/packages/node/src/indexer/dictionary/v2/ethDictionaryV2.spec.ts
+++ b/packages/node/src/indexer/dictionary/v2/ethDictionaryV2.spec.ts
@@ -28,7 +28,7 @@ import {
 } from './ethDictionaryV2';
 
 const DEFAULT_DICTIONARY = 'https://ethereum.node.subquery.network/public';
-const HTTP_ENDPOINT = 'https://eth.llamarpc.com';
+const HTTP_ENDPOINT = 'https://ethereum.rpc.subquery.network/public';
 const mockDs: EthereumProjectDs[] = [
   {
     kind: EthereumDatasourceKind.Runtime,

--- a/packages/node/src/indexer/dictionary/v2/utils.spec.ts
+++ b/packages/node/src/indexer/dictionary/v2/utils.spec.ts
@@ -10,7 +10,7 @@ import { RawEthBlock } from './types';
 import { rawBlockToEthBlock } from './utils';
 
 const DICTIONARY_URL = 'https://ethereum.node.subquery.network/public';
-const RPC_URL = 'https://eth.llamarpc.com';
+const RPC_URL = 'https://ethereum.rpc.subquery.network/public';
 
 async function fetchDictionaryBlock(): Promise<RawEthBlock> {
   const res = await fetch(DICTIONARY_URL, {

--- a/packages/node/src/indexer/project.service.test.ts
+++ b/packages/node/src/indexer/project.service.test.ts
@@ -5,7 +5,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { EthereumApi, EthereumApiService } from '../ethereum';
 import { ProjectService } from './project.service';
 
-const HTTP_ENDPOINT = 'https://eth.llamarpc.com';
+const HTTP_ENDPOINT = 'https://ethereum.rpc.subquery.network/public';
 
 const mockApiService = (): EthereumApiService => {
   const ethApi = new EthereumApi(HTTP_ENDPOINT, 20, new EventEmitter2());


### PR DESCRIPTION
# Description
In order to support api keys in headers we convert query params to headers, this stripped the query params, there was no need to strip the query params, this keeps the query params as provided in the config

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
