### PR TITLE
Fix dict last buffered

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Empty dictionary v2 response resulting in all blocks within that range being indexed (#336)
 
 ## [5.1.0] - 2024-08-02
 ### Added

--- a/packages/node/src/indexer/dictionary/v2/ethDictionaryV2.spec.ts
+++ b/packages/node/src/indexer/dictionary/v2/ethDictionaryV2.spec.ts
@@ -313,6 +313,7 @@ describe('eth dictionary v2', () => {
 
     const res = await ethDictionaryV2.getData(18723210, 18733210, 100);
 
+    expect(res?.batchBlocks.length).toEqual(0);
     expect(res?.lastBufferedHeight).toEqual(18733210);
   });
 });

--- a/packages/node/src/indexer/dictionary/v2/ethDictionaryV2.spec.ts
+++ b/packages/node/src/indexer/dictionary/v2/ethDictionaryV2.spec.ts
@@ -284,6 +284,37 @@ describe('eth dictionary v2', () => {
     // Uncomment this when not null filter supported
     // expect(logs.filter(l => !l.topics[3]).length).toEqual(6) // There are 6 events with no topic3
   }, 100000);
+
+  it('returns a lastBufferedHeight if there are no block results', async () => {
+    const ds: SubqlRuntimeDatasource = {
+      kind: EthereumDatasourceKind.Runtime,
+      assets: new Map(),
+      options: {
+        abi: 'erc20',
+        address: '0x30baa3ba9d7089fd8d020a994db75d14cf7ec83b',
+      },
+      startBlock: 18723210,
+      mapping: {
+        file: '',
+        handlers: [
+          {
+            handler: 'handleLog',
+            kind: EthereumHandlerKind.Event,
+            filter: {
+              topics: ['Transfer(address, address, uint256)'],
+            },
+          },
+        ],
+      },
+    };
+
+    const dsMap = makeBlockHeightMap([ds]);
+    ethDictionaryV2.updateQueriesMap(dsMap);
+
+    const res = await ethDictionaryV2.getData(18723210, 18733210, 100);
+
+    expect(res?.lastBufferedHeight).toEqual(18733210);
+  });
 });
 
 describe('buildDictionaryV2QueryEntry', () => {

--- a/packages/node/src/indexer/dictionary/v2/ethDictionaryV2.ts
+++ b/packages/node/src/indexer/dictionary/v2/ethDictionaryV2.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import { BigNumber } from '@ethersproject/bignumber';
 import {
   NodeConfig,
   DictionaryV2,
@@ -285,7 +286,10 @@ export class EthDictionaryV2 extends DictionaryV2<
       ).map((b) => rawBlockToEthBlock(b, this.api));
 
       if (!blocks.length) {
-        return undefined;
+        return {
+          batchBlocks: [],
+          lastBufferedHeight: undefined, // This will get set to the request end block in the base class.
+        } as any;
       }
       return {
         batchBlocks: blocks,


### PR DESCRIPTION
# Description
If the dictionary v2 response contained no blocks then it would result in indexing each block within that range manually. This fixes that by making sure the last buffered height is set to the end block of the requested range.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
