### PR TITLE
Do not index data when fullBlock does not exist logs

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Do not index data when fullBlock does not exist logs (#350)
+- When there is no log data for fullBlock, it is determined as lightBlock. (#350)
 
 ## [5.1.6] - 2024-10-23
 ### Changed

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Do not index data when fullBlock does not exist logs (#)
+- Do not index data when fullBlock does not exist logs (#350)
 
 ## [5.1.5] - 2024-10-22
 ### Changed

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Do not index data when fullBlock does not exist logs (#)
+
 ## [5.1.5] - 2024-10-22
 ### Changed
 - Bump `@subql/node-core` dependency (#347)

--- a/packages/node/src/ethereum/api.ethereum.test.ts
+++ b/packages/node/src/ethereum/api.ethereum.test.ts
@@ -368,9 +368,8 @@ describe('Api.ethereum', () => {
     expect(isFullBlock(blockData)).toBeTruthy();
     expect(isFullBlock(lightBlock)).toBeFalsy();
 
-    // block with transactions, but no logs
-    const noLogBlockData = _.cloneDeep(blockData);
-    noLogBlockData.logs = [];
+    // block with transactions, but no logs 4913287
+    const noLogBlockData = (await (ethApi as any).fetchBlock(4913287)).block;
     expect(isFullBlock(noLogBlockData)).toBeTruthy();
 
     // block without transaction

--- a/packages/node/src/ethereum/api.ethereum.test.ts
+++ b/packages/node/src/ethereum/api.ethereum.test.ts
@@ -11,6 +11,7 @@ import {
   EthereumLogFilter,
   SubqlRuntimeDatasource,
 } from '@subql/types-ethereum';
+import _ from 'lodash';
 import { EthereumApi } from './api.ethereum';
 import {
   filterLogsProcessor,
@@ -366,6 +367,11 @@ describe('Api.ethereum', () => {
     const lightBlock = (await (ethApi as any).fetchLightBlock(16258633)).block;
     expect(isFullBlock(blockData)).toBeTruthy();
     expect(isFullBlock(lightBlock)).toBeFalsy();
+
+    // block with transactions, but no logs
+    const noLogBlockData = _.cloneDeep(blockData);
+    noLogBlockData.logs = [];
+    expect(isFullBlock(noLogBlockData)).toBeTruthy();
 
     // block without transaction
     const block10001 = (await (ethApi as any).fetchBlock(10001)).block;

--- a/packages/node/src/ethereum/api.ethereum.test.ts
+++ b/packages/node/src/ethereum/api.ethereum.test.ts
@@ -11,7 +11,6 @@ import {
   EthereumLogFilter,
   SubqlRuntimeDatasource,
 } from '@subql/types-ethereum';
-import _ from 'lodash';
 import { EthereumApi } from './api.ethereum';
 import {
   filterLogsProcessor,

--- a/packages/node/src/ethereum/block.ethereum.ts
+++ b/packages/node/src/ethereum/block.ethereum.ts
@@ -120,7 +120,7 @@ export function isFullBlock(block: BlockContent): block is EthereumBlock {
   // Light etherum block just contains transaction hashes for transactions.
   // If the block has no transactions then both types would be the same
 
-  if (block.transactions.length && block.logs.length) {
+  if (block.transactions.length) {
     return typeof (block as EthereumBlock).transactions[0] !== 'string';
   }
   return false;


### PR DESCRIPTION
# Description
Do not index data when fullBlock does not exist logs.

Fixes https://github.com/subquery/subql/issues/2575

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
