### PR TITLE
Fix `Header` not found `timestamp` field

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+- Fix `Header` not found `timestamp` field
+
 ### Changed
 - Update header year to 2025 (#362)
 

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Fix `Header` not found `timestamp` field
+- `timestamp` field missing on `Header`
 
 ### Changed
 - Update header year to 2025 (#362)

--- a/packages/node/src/ethereum/utils.ethereum.ts
+++ b/packages/node/src/ethereum/utils.ethereum.ts
@@ -158,5 +158,6 @@ export function ethereumBlockToHeader(block: BlockContent | Block): Header {
     blockHeight: block.number,
     blockHash: block.hash,
     parentHash: block.parentHash,
+    timestamp: new Date(Number(block.timestamp) * 1000),
   };
 }

--- a/packages/node/src/indexer/unfinalizedBlocks.service.spec.ts
+++ b/packages/node/src/indexer/unfinalizedBlocks.service.spec.ts
@@ -20,7 +20,7 @@ const hexify = (input: string) => hexZeroPad(input, 4);
 
 // Mock 1740100000 is the timestamp of the genesis block
 const genBlockTimestamp = (height: number) => (1740100000 + height) * 1000;
-const genBlockDate = (height: number) => new Date((1740100000 + height) * 1000);
+const genBlockDate = (height: number) => new Date(genBlockTimestamp(height));
 
 const makeHeader = (height: number, finalized?: boolean): Header => ({
   blockHeight: height,

--- a/packages/node/src/indexer/unfinalizedBlocks.service.spec.ts
+++ b/packages/node/src/indexer/unfinalizedBlocks.service.spec.ts
@@ -47,14 +47,14 @@ const getMockApi = (): ApiService => {
           number: num,
           hash: typeof hash === 'number' ? hexify(`0xABC${hash}f`) : hash,
           parentHash: hexify(`0xABC${num - 1}f`),
-          timestamp: genBlockTimestamp(num),
+          timestamp: genBlockTimestamp(num) / 1000,
         });
       },
       getFinalizedBlock: jest.fn(() => ({
         number: 110,
         hash: '0xABC110f',
         parentHash: '0xABC109f',
-        timestamp: genBlockTimestamp(110),
+        timestamp: genBlockTimestamp(110) / 1000,
       })),
     },
   } as any;
@@ -196,7 +196,7 @@ describe('UnfinalizedBlockService', () => {
       blockHash: '0x00ABC99f',
       blockHeight: 99,
       parentHash: '0x00ABC98f',
-      timestamp: genBlockTimestamp(99),
+      timestamp: genBlockDate(99),
     });
   });
 

--- a/packages/node/src/indexer/unfinalizedBlocks.service.spec.ts
+++ b/packages/node/src/indexer/unfinalizedBlocks.service.spec.ts
@@ -22,6 +22,7 @@ const makeHeader = (height: number, finalized?: boolean): Header => ({
   blockHeight: height,
   blockHash: hexify(`0xABC${height}${finalized ? 'f' : ''}`),
   parentHash: hexify(`0xABC${height - 1}${finalized ? 'f' : ''}`),
+  timestamp: new Date((1740100000 + height) * 1000),
 });
 
 const getMockApi = (): ApiService => {
@@ -42,12 +43,14 @@ const getMockApi = (): ApiService => {
           number: num,
           hash: typeof hash === 'number' ? hexify(`0xABC${hash}f`) : hash,
           parentHash: hexify(`0xABC${num - 1}f`),
+          timestamp: 1740100000 + num,
         });
       },
       getFinalizedBlock: jest.fn(() => ({
         number: 110,
         hash: '0xABC110f',
         parentHash: '0xABC109f',
+        timestamp: 1740100000 + 110,
       })),
     },
   } as any;
@@ -164,6 +167,7 @@ describe('UnfinalizedBlockService', () => {
       blockHash: '0x00ABC99f',
       blockHeight: 99,
       parentHash: '0x00ABC98f',
+      timestamp: new Date((1740100000 + 99) * 1000),
     });
   });
 
@@ -188,6 +192,7 @@ describe('UnfinalizedBlockService', () => {
       blockHash: '0x00ABC99f',
       blockHeight: 99,
       parentHash: '0x00ABC98f',
+      timestamp: new Date((1740100000 + 99) * 1000),
     });
   });
 

--- a/packages/node/src/indexer/unfinalizedBlocks.service.spec.ts
+++ b/packages/node/src/indexer/unfinalizedBlocks.service.spec.ts
@@ -18,11 +18,15 @@ import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
 // Adds 0 padding so we can convert to POI block
 const hexify = (input: string) => hexZeroPad(input, 4);
 
+// Mock 1740100000 is the timestamp of the genesis block
+const genBlockTimestamp = (height: number) => (1740100000 + height) * 1000;
+const genBlockDate = (height: number) => new Date((1740100000 + height) * 1000);
+
 const makeHeader = (height: number, finalized?: boolean): Header => ({
   blockHeight: height,
   blockHash: hexify(`0xABC${height}${finalized ? 'f' : ''}`),
   parentHash: hexify(`0xABC${height - 1}${finalized ? 'f' : ''}`),
-  timestamp: new Date((1740100000 + height) * 1000),
+  timestamp: genBlockDate(height),
 });
 
 const getMockApi = (): ApiService => {
@@ -43,14 +47,14 @@ const getMockApi = (): ApiService => {
           number: num,
           hash: typeof hash === 'number' ? hexify(`0xABC${hash}f`) : hash,
           parentHash: hexify(`0xABC${num - 1}f`),
-          timestamp: 1740100000 + num,
+          timestamp: genBlockTimestamp(num),
         });
       },
       getFinalizedBlock: jest.fn(() => ({
         number: 110,
         hash: '0xABC110f',
         parentHash: '0xABC109f',
-        timestamp: 1740100000 + 110,
+        timestamp: genBlockTimestamp(110),
       })),
     },
   } as any;
@@ -167,7 +171,7 @@ describe('UnfinalizedBlockService', () => {
       blockHash: '0x00ABC99f',
       blockHeight: 99,
       parentHash: '0x00ABC98f',
-      timestamp: new Date((1740100000 + 99) * 1000),
+      timestamp: genBlockDate(99),
     });
   });
 
@@ -192,7 +196,7 @@ describe('UnfinalizedBlockService', () => {
       blockHash: '0x00ABC99f',
       blockHeight: 99,
       parentHash: '0x00ABC98f',
-      timestamp: new Date((1740100000 + 99) * 1000),
+      timestamp: genBlockTimestamp(99),
     });
   });
 


### PR DESCRIPTION
# Description
When using historical: timestamp, because getHeader does not return the timestamp, it causes the crawl to not function properly.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
