### PR TITLE
Fix incomplete event indexing for SEI based EVM chains

### DIFF
--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -125,6 +125,18 @@ export class IndexerManager extends BaseIndexerManager<
           await this.indexEvent(log, dataSources, getVM);
         }
       }
+
+      // Handle Cosmos/Sei-injected synthetic logs whose parent tx is not visible in
+      // eth_getBlockByNumber (type 0xffffffff shell receipts, excluded from eth_ namespace).
+      // Their logs are still returned by eth_getLogs via the block-level bloom filter.
+      const txHashes = new Set(
+        block.transactions.map((tx) => tx.hash.toLowerCase()),
+      );
+      for (const log of block.logs ?? []) {
+        if (!txHashes.has(log.transactionHash.toLowerCase())) {
+          await this.indexEvent(log, dataSources, getVM);
+        }
+      }
     } else {
       for (const log of block.logs ?? []) {
         await this.indexEvent(log, dataSources, getVM);

--- a/packages/node/src/indexer/unfinalizedBlocks.service.ts
+++ b/packages/node/src/indexer/unfinalizedBlocks.service.ts
@@ -146,13 +146,13 @@ export class UnfinalizedBlocksService extends BaseUnfinalizedBlocksService<Block
       return poiHeader;
     } catch (e: any) {
       if (e.message === POI_NOT_ENABLED_ERROR_MESSAGE) {
-        return {
-          blockHeight: Math.max(
+        return this.blockchainService.getHeaderForHeight(
+          Math.max(
             0,
             forkedHeader.blockHeight -
               (this.nodeConfig as EthereumNodeConfig).blockForkReindex,
           ),
-        } as Header;
+        );
       }
       // TODO rewind back 1000+ blocks
       logger.info('Failed to use POI to rewind block');


### PR DESCRIPTION
This PR fixes incomplete event indexing for Cosmos/Sei-based EVM chains where synthetic logs are injected at the block level.

In these environments, some logs are emitted from transactions that are **not returned via `eth_getBlockByNumber`**, but are still discoverable through `eth_getLogs` due to block-level bloom filtering. These logs were previously skipped because the indexer only processed logs tied to visible transactions.

### What was changed

* Added additional handling in `IndexerManager` to process **synthetic logs** whose `transactionHash` is not present in the block’s transaction list.

* Introduced a fallback mechanism that:

  * Collects all transaction hashes from the block
  * Iterates over all logs in the block
  * Indexes logs that belong to unknown (synthetic) transactions

* Improved rewind logic in `UnfinalizedBlocksService`:

  * Replaced unsafe POI fallback with a direct call to `getHeaderForHeight`
  * Ensures consistent and safer rewind behavior when POI is not enabled

### Motivation

Without this fix:

* Some valid events on Cosmos/Sei EVM chains were silently ignored
* This could lead to **data inconsistency**, missing indexed events, and incorrect downstream state

This change ensures compatibility with hybrid EVM implementations that inject logs outside standard Ethereum transaction visibility.

Fixes # (issue)

---

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

---

## Checklist

* [x] I have tested locally
* [x] I have performed a self review of my changes
* [ ] Updated any relevant documentation
* [ ] Linked to any relevant issues
* [ ] I have added tests relevant to my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [x] My code is up to date with the base branch
* [ ] I have updated relevant changelogs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Fixed indexing of synthetic Cosmos/Sei logs that were previously missed during full block processing.
* Improved accuracy of finalized block header retrieval by ensuring complete header data is fetched when using standard confirmation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->